### PR TITLE
Fix setting environment variables

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -29,8 +29,8 @@ jobs:
     # Get date and store as environment variables
     - name: Get and store variables
       run: |
-        echo ::set-env name=BRANCH_NAME::$(date +%F)
-        echo ::set-env name=WEEK_OF::"Week of $(date '+%B %d, %Y')"
+        echo "BRANCH_NAME=$(date +%F)" >> $GITHUB_ENV
+        echo "WEEK_OF="Week of $(date '+%B %d, %Y')"" >> $GITHUB_ENV
 
     # Create meeting notes scaffold
     - name: Create weekly notes scaffold file


### PR DESCRIPTION
Setting environment variables via `set-env` has recently been [deprecated due to security issues](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).

The changes in this commit fix that by using `$GITHUB_ENV`.